### PR TITLE
grunt-bower-task does not seem to honor .bowerrc

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -23,6 +23,9 @@ module.exports = function(grunt) {
     },
     bower: {
       install: {
+        options: {
+          targetDir: './src/lib/vendor'
+        }
       }
     },
     jshint: {


### PR DESCRIPTION
@mikemilano, noticed that `bower install` via `grunt` does not seem to honor the config in `bowerrc` ... this results in a potential double install if you run `bower install` separately. This should get us on the same page. 

Let me know if this makes sense to you and i'll merge it in!
