### PR TITLE
21 ci testing and builds

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,24 @@
+{
+  "node": true,
+  "browser": true,
+  "esnext": true,
+  "bitwise": true,
+  "camelcase": true,
+  "curly": true,
+  "eqeqeq": true,
+  "immed": true,
+  "indent": 2,
+  "latedef": true,
+  "newcap": true,
+  "noarg": true,
+  "quotmark": "single",
+  "regexp": true,
+  "undef": true,
+  "unused": true,
+  "strict": true,
+  "trailing": true,
+  "smarttabs": true,
+  "globals": {
+    "angular": false
+  }
+}

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -26,6 +26,10 @@ module.exports = function(grunt) {
       }
     },
     jshint: {
+      options: {
+        jshintrc: '.jshintrc',
+        reporter: require('jshint-stylish')
+      },
       all: ['Gruntfile.js', '<%= files.js.src %>']
     },
     less: {

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -96,5 +96,6 @@ module.exports = function(grunt) {
 
   // create workflows
   grunt.registerTask('default', ['bower', 'jshint', 'less:dev', 'watch']);
+  grunt.registerTask('test', ['jshint']);
   grunt.registerTask('build', ['clean', 'bower', 'jshint', 'less:dist', 'copy', 'nodewebkit']);
 };

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,5 +1,8 @@
+'use strict';
+
 module.exports = function(grunt) {
-  var dist = '' + (process.env.SERVER_BASE || 'dist_dev');
+  // commenting this out for now until used
+  //var dist = '' + (process.env.SERVER_BASE || 'dist_dev');
   var config = {
     pkg: grunt.file.readJSON('package.json'),
     files: {

--- a/package.json
+++ b/package.json
@@ -16,15 +16,16 @@
     "lodash": "~2.4.1"
   },
   "devDependencies": {
-    "grunt": "~0.4.5",
-    "grunt-contrib-watch": "~0.6.1",
-    "grunt-contrib-less": "~0.11.4",
-    "grunt-contrib-copy": "~0.5.0",
-    "grunt-contrib-clean": "~0.6.0",
     "compression": "~1.0.9",
-    "matchdep": "~0.3.0",
-    "grunt-contrib-jshint": "~0.10.0",
+    "grunt": "~0.4.5",
     "grunt-bower-task": "~0.4.0",
-    "grunt-node-webkit-builder": "~0.2.1"
+    "grunt-contrib-clean": "~0.6.0",
+    "grunt-contrib-copy": "~0.5.0",
+    "grunt-contrib-jshint": "~0.10.0",
+    "grunt-contrib-less": "~0.11.4",
+    "grunt-contrib-watch": "~0.6.1",
+    "grunt-node-webkit-builder": "~0.2.1",
+    "jshint-stylish": "^0.4.0",
+    "matchdep": "~0.3.0"
   }
 }

--- a/src/app.js
+++ b/src/app.js
@@ -1,3 +1,5 @@
+'use strict';
+
 angular.module('app', [
     'ngRoute',
     'kalabox.nodewrappers',

--- a/src/modules/dashboard/dashboard.js
+++ b/src/modules/dashboard/dashboard.js
@@ -1,3 +1,5 @@
+'use strict';
+
 angular.module('kalabox.dashboard', [])
   .config(function ($routeProvider) {
     $routeProvider.when('/dashboard', {

--- a/src/modules/installer/installer.html
+++ b/src/modules/installer/installer.html
@@ -10,7 +10,7 @@
   </div>
   <hr>
   <div class="progress progress-striped default active">
-    <div class="progress-bar" style="width: {{ui.step_progress}}%;"></div>
+    <div class="progress-bar" style="width: {{ui.stepProgress}}%;"></div>
   </div>
 </div>
 

--- a/src/modules/installer/installer.js
+++ b/src/modules/installer/installer.js
@@ -1,3 +1,5 @@
+'use strict';
+
 angular.module('kalabox.installer', [])
   .config(function ($routeProvider) {
     $routeProvider.when('/installer', {
@@ -21,27 +23,27 @@ angular.module('kalabox.installer', [])
     $scope.ui = {
       title: 'Checking Prerequisites',
       detail: 'Testing Firewall',
-      step_progress: 5
+      stepProgress: 5
     };
   })
   .controller('InstallerDownloadCtrl', function ($scope) {
     $scope.ui = {
       title: 'Downloading Files',
       detail: '',
-      step_progress: 5
+      stepProgress: 5
     };
   })
   .controller('InstallerVBoxCtrl', function ($scope) {
     $scope.ui = {
       title: 'Installing VirtualBox',
       detail: '',
-      step_progress: 5
+      stepProgress: 5
     };
   })
   .controller('InstallerDockerCtrl', function ($scope) {
     $scope.ui = {
       title: 'Installing Docker',
       detail: '',
-      step_progress: 5
+      stepProgress: 5
     };
   });

--- a/src/modules/nodewrappers/nodewrappers.js
+++ b/src/modules/nodewrappers/nodewrappers.js
@@ -1,3 +1,5 @@
+'use strict';
+
 angular.
   module('kalabox.nodewrappers', [])
   .factory('fs', [function() {


### PR DESCRIPTION
@mikemilano

i've added some node standards when it comes to jshint... my big ? here is whether 'use strict' could cause issues in older browsers. @bassettsj may have some insight as well. 

I added a new grunt task specifically for testing since `watch` is a non-starter in our drone.io CI integration. 

Want to get a thumbs up here before i merge!
