### PR TITLE
Karma config and dependencies for nodewebkit runner

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -188,11 +188,16 @@ module.exports = function(grunt) {
         configFile: 'test/karma.conf.js'
       },
       // Required by grunt, can override later.
-      unit: {},
+      unit: {
+        options: {
+          singleRun: true,
+          browsers: ['NodeWebkit']
+        }
+      },
       ci: {
         options: {
           singleRun: true,
-          browsers: ['PhantomJS']
+          browsers: ['NodeWebkit']
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -42,6 +42,8 @@
     "karma-jasmine": "^0.1.5",
     "karma-ng-html2js-preprocessor": "^0.1.0",
     "karma-phantomjs-launcher": "^0.1.4",
-    "matchdep": "~0.3.0"
+    "matchdep": "~0.3.0",
+    "karma-nodewebkit-launcher": "https://github.com/nDmitry/karma-nodewebkit-launcher/tarball/master",
+    "nodewebkit": "~0.10.2"
   }
 }

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -41,14 +41,15 @@ module.exports = function(config) {
     // - PhantomJS
     // - IE (only Windows)
     browsers: [
-      'Chrome'
+      'NodeWebkit'
     ],
 
     // Which plugins to enable
     plugins: [
+      'karma-chrome-launcher',
+      'karma-nodewebkit-launcher',
       'karma-phantomjs-launcher',
       'karma-jasmine',
-      'karma-chrome-launcher',
       'karma-coverage',
       'karma-ng-html2js-preprocessor'
     ],


### PR DESCRIPTION
This makes karma work.

You will need to run npm install to put nodewebkit in the node_modules directory. Karma depends on that to test properly.

`grunt karma:unit` will run just the unit tests.

`grunt test` should run the karma tests now just fine as well.
