### PR TITLE
Protractor support & platform configs

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -211,12 +211,6 @@ module.exports = function(grunt) {
           singleRun: true,
           browsers: ['NodeWebkit']
         }
-      },
-      ci: {
-        options: {
-          singleRun: true,
-          browsers: ['NodeWebkit']
-        }
       }
     },
     /**
@@ -261,7 +255,22 @@ module.exports = function(grunt) {
     'jshint',
     'jscs',
     'bower-install-simple:ci',
-    'karma:ci'
+    'test:unit',
+    'test:e2e'
+  ]);
+
+  grunt.registerTask('test:js', [
+    'jshint',
+    'jscs',
+  ]);
+
+  grunt.registerTask('test:unit', [
+    'karma:unit'
+  ]);
+
+  grunt.registerTask('test:e2e', [
+    'protractor-setup',
+    'protractor:default'
   ]);
 
   grunt.registerTask('prepare', [
@@ -269,7 +278,7 @@ module.exports = function(grunt) {
     'bower-install-simple:install',
     'jshint',
     'jscs',
-    'karma:ci',
+    'karma:unit',
     'less:dist',
     'copy'
   ]);
@@ -280,11 +289,6 @@ module.exports = function(grunt) {
     'compress:osx',
     'compress:linux32',
     'compress:linux64'
-  ]);
-
-  grunt.registerTask('e2e', [
-    'protractor-setup',
-    'protractor:default'
   ]);
 
   grunt.registerTask('version', [

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -192,7 +192,7 @@ module.exports = function(grunt) {
     nodewebkit: {
       options: {
         // Versions listed here: http://dl.node-webkit.org/
-        version: 'v0.10.1',
+        version: 'v0.10.2',
         platforms: ['win', 'osx', 'linux32', 'linux64'],
         buildDir: 'dist'
       },
@@ -284,6 +284,7 @@ module.exports = function(grunt) {
   ]);
 
   grunt.registerTask('build', [
+    'copy',
     'nodewebkit',
     'compress:win',
     'compress:osx',

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -4,14 +4,8 @@ module.exports = function(grunt) {
   // commenting this out for now until used
   //var dist = '' + (process.env.SERVER_BASE || 'dist_dev');
 
-  // Set platform for nw binary selection.
   var path = require('path');
-  var platform = require('os').platform();
-  var nwBinaries = {
-    linux: path.normalize('node_modules/nodewebkit/nodewebkit/nw'),
-    darwin: path.normalize('node_modules/nodewebkit/nodewebkit/node-webkit.app/Contents/MacOS/node-webkit'),
-    win32: path.normalize('node_modules/nodewebkit/nodewebkit/nw.exe')
-  };
+  var pconfig = require('./src/lib/pconfig');
 
   var config = {
     pkg: grunt.file.readJSON('package.json'),
@@ -106,7 +100,7 @@ module.exports = function(grunt) {
     },
     shell: {
       nw: {
-        command: nwBinaries[platform] + ' .'
+        command: pconfig.devBinary + ' .'
       }
     },
     jshint: {
@@ -132,7 +126,12 @@ module.exports = function(grunt) {
           rootElement: 'body'
         }
       },
-      default: {}
+      default: {
+        specs: [
+          'test/e2e/**/*.spec.js',
+          'src/modules/*/test/e2e/**/*.spec.js'
+        ]
+      }
     },
     /**
      * Simple server for testing and dev.
@@ -284,7 +283,8 @@ module.exports = function(grunt) {
   ]);
 
   grunt.registerTask('e2e', [
-    'protractor'
+    'protractor-setup',
+    'protractor:default'
   ]);
 
   grunt.registerTask('version', [

--- a/config/platform.json
+++ b/config/platform.json
@@ -1,0 +1,31 @@
+{
+  "platform": [
+    "darwin",
+    "linux",
+    "win32"
+  ],
+  "chromedriverDownload": [
+    "http://dl.node-webkit.org/v0.10.2/chromedriver-nw-v0.10.2-osx-x64.zip",
+    "http://dl.node-webkit.org/v0.10.2/chromedriver-nw-v0.10.2-linux-x64.tar.gz",
+    "http://dl.node-webkit.org/v0.10.2/chromedriver-nw-v0.10.2-win-ia32.zip"
+  ],
+  "devBinary": [
+    "node_modules/nodewebkit/nodewebkit/node-webkit.app/Contents/MacOS/node-webkit",
+    "node_modules/nodewebkit/nodewebkit/nw",
+    "node_modules/nodewebkit/nodewebkit/nw.exe"
+  ],
+  "devSymlink": [
+    {
+      "path": "node_modules/nodewebkit/nodewebkit",
+      "file": "node-webkit.app"
+    },
+    {
+      "path": "node_modules/nodewebkit/nodewebkit",
+      "file": "node-webkit.app"
+    },
+    {
+      "path": "node_modules/nodewebkit/nodewebkit",
+      "file": "node-webkit.app"
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "karma-phantomjs-launcher": "^0.1.4",
     "matchdep": "~0.3.0",
     "nodewebkit": "~0.10.1",
-    "protractor": "https://github.com/kalabox/protractor/tarball/master"
+    "protractor": "https://github.com/kalabox/protractor/tarball/master",
+    "unzip": "~0.1.9"
   }
 }

--- a/src/lib/pconfig.js
+++ b/src/lib/pconfig.js
@@ -4,21 +4,18 @@ var _ = require('lodash'),
   platform = require('os').platform(),
   raw_config = require('../../config/platform.json');
 
-// reduce callback to get platform index
-var getIndex = function(result, val, key) {
-  if (result !== false) {
-    return result;
-  }
-  return val == platform ? key : false;
+// findIndex callback to get platform
+var getIndex = function(val) {
+  return val === platform;
 };
 
-// map callback to get a specific platform config.
+// map callback to set a specific platform config.
 var getConfig = function(options, key, config) {
   return [key, key == 'index' ? config.index : options[config.index]];
 };
 
 // set index
-raw_config.index = _.reduce(raw_config.platform, getIndex, false);
+raw_config.index = _.findIndex(raw_config.platform, getIndex);
 
 // export a processed config
 module.exports = _.object(_.map(raw_config, getConfig));

--- a/src/lib/pconfig.js
+++ b/src/lib/pconfig.js
@@ -1,0 +1,24 @@
+'use strict';
+
+var _ = require('lodash'),
+  platform = require('os').platform(),
+  raw_config = require('../../config/platform.json');
+
+// reduce callback to get platform index
+var getIndex = function(result, val, key) {
+  if (result !== false) {
+    return result;
+  }
+  return val == platform ? key : false;
+};
+
+// map callback to get a specific platform config.
+var getConfig = function(options, key, config) {
+  return [key, key == 'index' ? config.index : options[config.index]];
+};
+
+// set index
+raw_config.index = _.reduce(raw_config.platform, getIndex, false);
+
+// export a processed config
+module.exports = _.object(_.map(raw_config, getConfig));

--- a/src/modules/initialize/initialize.js
+++ b/src/modules/initialize/initialize.js
@@ -13,7 +13,7 @@ angular.module('kalabox.initialize', [])
 
       var gui = require('nw.gui');
       var mb = new gui.Menu({type: 'menubar'});
-      mb.createMacBuiltin("Kalabox", {hideEdit: true, hideWindow: true});
+      mb.createMacBuiltin('Kalabox', {hideEdit: true, hideWindow: true});
       gui.Window.get().menu = mb;
 
       // Best practices is to manage our data in a scope object

--- a/src/modules/initialize/initialize.js
+++ b/src/modules/initialize/initialize.js
@@ -9,7 +9,13 @@ angular.module('kalabox.initialize', [])
   })
   .controller('InitializeCtrl',
   ['$scope', '$location', '_', 'VirtualBox', 'Boot2Docker',
-    function ($scope, $location, _, VirtualBox, Boot2Docker) {
+    function ($scope, $location, _, GUI, VirtualBox, Boot2Docker) {
+
+      var gui = require('nw.gui');
+      var mb = new gui.Menu({type: 'menubar'});
+      mb.createMacBuiltin("Kalabox", {hideEdit: true, hideWindow: true});
+      gui.Window.get().menu = mb;
+
       // Best practices is to manage our data in a scope object
       $scope.ui = {
         messageText: 'Testing dependencies...'

--- a/tasks/protractor-setup.js
+++ b/tasks/protractor-setup.js
@@ -1,0 +1,82 @@
+module.exports = function(grunt) {
+  grunt.registerTask('protractor-setup', 'Protractor setup task', function() {
+    // quick check for the appropriate directories to run protractor
+    var fs = require('fs');
+    var path = require('path');
+    var pconfig = require('../src/lib/pconfig');
+    var dir = 'test/support';
+
+    var symlinkDst = path.resolve(dir, pconfig.devSymlink.file);
+    var cdFile = path.resolve(dir, 'chromedriver');
+
+    var supportExists = fs.existsSync(dir);
+    var symlinkExists = fs.existsSync(symlinkDst);
+    var cdExists = fs.existsSync(cdFile);
+
+    if (supportExists && symlinkExists && cdExists) {
+      return;
+    }
+
+    // something doesn't exist so check & install everything.
+    var done = this.async();
+    var http = require('http');
+    var request = require('request');
+    var unzip = require('unzip');
+    var symlinkFile = pconfig.devSymlink.file;
+    var symlinkPath = path.normalize(pconfig.devSymlink.path);
+    var symlinkSrc = path.resolve(symlinkPath, symlinkFile);
+    var cdRemote = pconfig.chromedriverDownload;
+    var cdLocal = path.resolve(dir, pconfig.chromedriverDownload.split('/').pop());
+
+    var download = function(url, dest, cb, cbdone) {
+      var file = fs.createWriteStream(dest);
+      http.get(url, function(response) {
+        response.pipe(file);
+        file.on('finish', function() {
+          cb(cbdone);
+        });
+      });
+    };
+
+    var extractChromedriver = function(cbdone) {
+      grunt.log.writeln('Extracting node-webkit chromedriver.');
+
+      fs.createReadStream(cdLocal)
+        .pipe(unzip.Parse())
+        .on('entry', function (entry) {
+          if (entry.path.indexOf('/chromedriver') >= 0) {
+            entry.pipe(fs.createWriteStream(cdFile));
+          } else {
+            entry.autodrain();
+          }
+        })
+        .on('end', function() {
+          // *nix only?
+          // TODO: Fix chmod not working on at least osx
+          fs.chmodSync(cdFile, '0755');
+          grunt.log.writeln('Protractor setup is complete.');
+          grunt.log.writeln('To run tests, you may now run: grunt e2e');
+          cbdone();
+        });
+    };
+
+    if (!supportExists) {
+      grunt.log.writeln('Creating support directory.');
+      fs.mkdir(dir);
+    }
+
+    if (!symlinkExists) {
+      grunt.log.writeln('Creating support link to node-webkit.');
+      fs.symlinkSync(symlinkSrc, symlinkDst);
+    }
+
+    if (!cdExists) {
+      grunt.log.writeln('Downloading node-webkit chromedriver.');
+      download(
+        cdRemote,
+        cdLocal,
+        extractChromedriver,
+        done);
+    }
+  });
+};


### PR DESCRIPTION
There's a lot going on here.
- added protractor configs to the grunt file
- added a custom task to handle creating the support directory. it downloads the node-webkit chromedriver, extracts it, and creates the necessary symlink to run protractor.

There were a few platform-specific files to manage so I created a `config.platform.json` file and a node module `src/lib/pconfig.js` to take the platform config and return properties relevant to the local system. I figured `src/lib` would be a good place for non-angular nodejs modules.

`grunt protractor-setup` will run the setup, and it will run before `grunt e2e` as well. It will short out if it finds the  required files to move head.

The one thing I couldn't get working was `fs.chmodSync()`. The `test/support/chromedriver` needs to be executable, but that function was not doing it. You have to manually chmod it for now.
