### PR TITLE
82 protractor webdriver man up

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -101,6 +101,9 @@ module.exports = function(grunt) {
     shell: {
       nw: {
         command: pconfig.devBinary + ' .'
+      },
+      build: {
+        command: 'cd ./generated && npm install --production --ignore-scripts'
       }
     },
     jshint: {
@@ -273,18 +276,13 @@ module.exports = function(grunt) {
     'protractor:default'
   ]);
 
-  grunt.registerTask('prepare', [
+  grunt.registerTask('build', [
     'clean',
     'bower-install-simple:install',
-    'jshint',
-    'jscs',
-    'karma:unit',
+    'test',
     'less:dist',
-    'copy'
-  ]);
-
-  grunt.registerTask('build', [
     'copy',
+    'shell:build',
     'nodewebkit',
     'compress:win',
     'compress:osx',

--- a/README.md
+++ b/README.md
@@ -91,10 +91,7 @@ We assume you've downloaded your kalabox source into `$HOME/kalabox`.
 ```
 cd $HOME/kalabox
 npm install
-grunt prepare
-cd $HOME/kalabox/generated
-npm install --production --ignore-scripts
-grunt build --force
+grunt build
 ```
 
 Kalabox binary should be in `$HOME/kalabox/built/(kalabox-linux32-dev.tar.gz|kalabox-linux64-dev.tar.gz|kalabox-osx-dev.tar.gz|kalabox-win-dev.zip)`

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "Kalabox",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "license": "N/A",
   "private": true,
   "dependencies": {

--- a/config/platform.json
+++ b/config/platform.json
@@ -6,7 +6,7 @@
   ],
   "chromedriverDownload": [
     "http://dl.node-webkit.org/v0.10.2/chromedriver-nw-v0.10.2-osx-x64.zip",
-    "http://dl.node-webkit.org/v0.10.2/chromedriver-nw-v0.10.2-linux-x64.tar.gz",
+    "http://files.kalamuna.com/chromedriver-nw-v0.10.2-linux-x64.zip",
     "http://dl.node-webkit.org/v0.10.2/chromedriver-nw-v0.10.2-win-ia32.zip"
   ],
   "devBinary": [

--- a/config/platform.json
+++ b/config/platform.json
@@ -20,12 +20,12 @@
       "file": "node-webkit.app"
     },
     {
-      "path": "node_modules/nodewebkit/nodewebkit",
-      "file": "node-webkit.app"
+      "path": "node_modules/nodewebkit/nodewebkit/nw",
+      "file": "nw"
     },
     {
-      "path": "node_modules/nodewebkit/nodewebkit",
-      "file": "node-webkit.app"
+      "path": "node_modules/nodewebkit/nodewebkit/nw.exe",
+      "file": "nw.exe"
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "matchdep": "~0.3.0",
     "nodewebkit": "~0.10.2",
     "protractor": "https://github.com/kalabox/protractor/tarball/master",
+    "request": "~2.40.0",
     "unzip": "~0.1.9"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Kalabox",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "main": "src/index.html",
   "private": true,
   "window": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
     "resizeable": "false"
   },
   "scripts": {
-    "postinstall": "node ./node_modules/grunt-protractor-runner/node_modules/.bin/webdriver-manager update",
     "test": "grunt test"
   },
   "dependencies": {
@@ -25,7 +24,7 @@
     "grunt-bower-install-simple": "^1.0.0",
     "grunt-bump": "0.0.15",
     "grunt-contrib-clean": "~0.6.0",
-    "grunt-contrib-compress": "git://github.com/kalabox/grunt-contrib-compress#master",
+    "grunt-contrib-compress": "https://github.com/kalabox/grunt-contrib-compress/tarball/master",
     "grunt-contrib-connect": "^0.8.0",
     "grunt-contrib-copy": "~0.5.0",
     "grunt-contrib-jshint": "~0.10.0",
@@ -42,10 +41,10 @@
     "karma-coverage": "^0.2.6",
     "karma-jasmine": "^0.1.5",
     "karma-ng-html2js-preprocessor": "^0.1.0",
-    "karma-nodewebkit-launcher": "git://github.com/kalabox/karma-nodewebkit-launcher#node-webkit-travis",
+    "karma-nodewebkit-launcher": "https://github.com/kalabox/karma-nodewebkit-launcher/tarball/node-webkit-travis",
     "karma-phantomjs-launcher": "^0.1.4",
     "matchdep": "~0.3.0",
-    "nodewebkit": "~0.10.1",
+    "nodewebkit": "~0.10.2",
     "protractor": "https://github.com/kalabox/protractor/tarball/master",
     "unzip": "~0.1.9"
   }

--- a/scripts/travis-ci.sh
+++ b/scripts/travis-ci.sh
@@ -40,21 +40,21 @@ before-install() {
     if [ ! -z $TRAVIS_TAG ]; then
       if [ $COMMIT_MINOR -le $CURRENT_MINOR ]; then
         echo "Illegal minor version number. Please use grunt release to roll an official release."
-        exit 666
+        set_error
       else
         if [ $COMMIT_PATCH -ne 0 ]; then
           echo "Illegal patch version number. Should be 0 on a minor version bump. Please use grunt release to bump the version."
-          exit 666
+          set_error
         fi
       fi
     else
       if [ $COMMIT_MINOR -ne $CURRENT_MINOR ]; then
         echo "Illegal minor version number. Minor versions should only change on a tag and release."
-        exit 666
+        set_error
       fi
       if [ $COMMIT_PATCH -le $CURRENT_PATCH ]; then
         echo "Illegal patch version number. Please use grunt version to bump the version."
-        exit 666
+        set_error
       fi
     fi
   fi
@@ -130,31 +130,17 @@ after-deploy() {
 # UTILITY FUNCTIONS:
 ##
 
-# Prints a message about the section of the script.
-header() {
-  set +xv
-  echo
-  echo "** $@"
-  echo
-  set -xv
-}
-
 # Sets the exit level to error.
 set_error() {
   EXIT_VALUE=1
 }
 
 # Runs a command and sets an error if it fails.
-run_test() {
+run_command() {
+  set -xv
   if ! $@; then
     set_error
   fi
-}
-
-# Runs a command showing all the lines executed
-run_command() {
-  set -xv
-  $@
   set +xv
 }
 

--- a/scripts/travis-ci.sh
+++ b/scripts/travis-ci.sh
@@ -95,10 +95,8 @@ after-script() {
 # Clean up after the tests.
 #
 after-success() {
-  DISPLAY=:99.0 grunt prepare
-  cd $TRAVIS_BUILD_DIR/generated
-  npm install --production --ignore-scripts
-  grunt build
+  cd $TRAVIS_BUILD_DIR
+  DISPLAY=:99.0 grunt build
   cd $TRAVIS_BUILD_DIR
 }
 


### PR DESCRIPTION
Some commits to start fixing our CI. This does the following:
1. Removes the old legacy `webdriver-manager update` on `postinstall`
2. installs `request` for `protractor-setup`as per #84 
3. refactors `grunt build` so it is a singular command again.

There are still some issues i will detail below that i can't get to right now.
