### PR TITLE
Linux support for e2e and misc

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -101,6 +101,9 @@ module.exports = function(grunt) {
     shell: {
       nw: {
         command: pconfig.devBinary + ' .'
+      },
+      build: {
+        command: 'cd ./generated && npm install --production --ignore-scripts'
       }
     },
     jshint: {
@@ -268,18 +271,13 @@ module.exports = function(grunt) {
     'protractor:default'
   ]);
 
-  grunt.registerTask('prepare', [
+  grunt.registerTask('build', [
     'clean',
     'bower-install-simple:install',
-    'jshint',
-    'jscs',
-    'karma:unit',
+    'test',
     'less:dist',
-    'copy'
-  ]);
-
-  grunt.registerTask('build', [
     'copy',
+    'shell:build',
     'nodewebkit',
     'compress:win',
     'compress:osx',

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -243,11 +243,6 @@ module.exports = function(grunt) {
     'bower-install-simple:install',
     'jshint',
     'less:dev',
-    'watch'
-  ]);
-
-  grunt.registerTask('run', [
-    'bower-install-simple:install',
     'shell:nw'
   ]);
 

--- a/README.md
+++ b/README.md
@@ -91,10 +91,7 @@ We assume you've downloaded your kalabox source into `$HOME/kalabox`.
 ```
 cd $HOME/kalabox
 npm install
-grunt prepare
-cd $HOME/kalabox/generated
-npm install --production --ignore-scripts
-grunt build --force
+grunt build
 ```
 
 Kalabox binary should be in `$HOME/kalabox/built/(kalabox-linux32-dev.tar.gz|kalabox-linux64-dev.tar.gz|kalabox-osx-dev.tar.gz|kalabox-win-dev.zip)`

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "Kalabox",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "license": "N/A",
   "private": true,
   "dependencies": {

--- a/config/platform.json
+++ b/config/platform.json
@@ -5,9 +5,9 @@
     "win32"
   ],
   "chromedriverDownload": [
-    "http://dl.node-webkit.org/v0.10.2/chromedriver-nw-v0.10.2-osx-x64.zip",
-    "http://dl.node-webkit.org/v0.10.2/chromedriver-nw-v0.10.2-linux-x64.tar.gz",
-    "http://dl.node-webkit.org/v0.10.2/chromedriver-nw-v0.10.2-win-ia32.zip"
+    "http://files.kalamuna.com/chromedriver-nw-v0.10.2-osx-x64.zip",
+    "http://files.kalamuna.com/chromedriver-nw-v0.10.2-linux-x64.tar.gz",
+    "http://files.kalamuna.com/chromedriver-nw-v0.10.2-win-ia32.zip"
   ],
   "devBinary": [
     "node_modules/nodewebkit/nodewebkit/node-webkit.app/Contents/MacOS/node-webkit",

--- a/config/platform.json
+++ b/config/platform.json
@@ -6,7 +6,7 @@
   ],
   "chromedriverDownload": [
     "http://dl.node-webkit.org/v0.10.2/chromedriver-nw-v0.10.2-osx-x64.zip",
-    "http://files.kalamuna.com/chromedriver-nw-v0.10.2-linux-x64.zip",
+    "http://dl.node-webkit.org/v0.10.2/chromedriver-nw-v0.10.2-linux-x64.tar.gz",
     "http://dl.node-webkit.org/v0.10.2/chromedriver-nw-v0.10.2-win-ia32.zip"
   ],
   "devBinary": [
@@ -20,11 +20,11 @@
       "file": "node-webkit.app"
     },
     {
-      "path": "node_modules/nodewebkit/nodewebkit/nw",
+      "path": "node_modules/nodewebkit/nodewebkit",
       "file": "nw"
     },
     {
-      "path": "node_modules/nodewebkit/nodewebkit/nw.exe",
+      "path": "node_modules/nodewebkit/nodewebkit",
       "file": "nw.exe"
     }
   ]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Kalabox",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "main": "src/index.html",
   "private": true,
   "window": {

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "matchdep": "~0.3.0",
     "nodewebkit": "~0.10.2",
     "protractor": "https://github.com/kalabox/protractor/tarball/master",
+    "request": "~2.40.0",
     "tar.gz": "~0.1.1",
     "unzip": "~0.1.9"
   }

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "matchdep": "~0.3.0",
     "nodewebkit": "~0.10.2",
     "protractor": "https://github.com/kalabox/protractor/tarball/master",
+    "tar.gz": "~0.1.1",
     "unzip": "~0.1.9"
   }
 }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
     "resizeable": "false"
   },
   "scripts": {
-    "postinstall": "node ./node_modules/grunt-protractor-runner/node_modules/.bin/webdriver-manager update",
     "test": "grunt test"
   },
   "dependencies": {
@@ -25,7 +24,7 @@
     "grunt-bower-install-simple": "^1.0.0",
     "grunt-bump": "0.0.15",
     "grunt-contrib-clean": "~0.6.0",
-    "grunt-contrib-compress": "git://github.com/kalabox/grunt-contrib-compress#master",
+    "grunt-contrib-compress": "https://github.com/kalabox/grunt-contrib-compress/tarball/master",
     "grunt-contrib-connect": "^0.8.0",
     "grunt-contrib-copy": "~0.5.0",
     "grunt-contrib-jshint": "~0.10.0",
@@ -42,7 +41,7 @@
     "karma-coverage": "^0.2.6",
     "karma-jasmine": "^0.1.5",
     "karma-ng-html2js-preprocessor": "^0.1.0",
-    "karma-nodewebkit-launcher": "git://github.com/kalabox/karma-nodewebkit-launcher#node-webkit-travis",
+    "karma-nodewebkit-launcher": "https://github.com/kalabox/karma-nodewebkit-launcher/tarball/node-webkit-travis",
     "karma-phantomjs-launcher": "^0.1.4",
     "matchdep": "~0.3.0",
     "nodewebkit": "~0.10.2",

--- a/scripts/travis-ci.sh
+++ b/scripts/travis-ci.sh
@@ -40,21 +40,21 @@ before-install() {
     if [ ! -z $TRAVIS_TAG ]; then
       if [ $COMMIT_MINOR -le $CURRENT_MINOR ]; then
         echo "Illegal minor version number. Please use grunt release to roll an official release."
-        exit 666
+        set_error
       else
         if [ $COMMIT_PATCH -ne 0 ]; then
           echo "Illegal patch version number. Should be 0 on a minor version bump. Please use grunt release to bump the version."
-          exit 666
+          set_error
         fi
       fi
     else
       if [ $COMMIT_MINOR -ne $CURRENT_MINOR ]; then
         echo "Illegal minor version number. Minor versions should only change on a tag and release."
-        exit 666
+        set_error
       fi
       if [ $COMMIT_PATCH -le $CURRENT_PATCH ]; then
         echo "Illegal patch version number. Please use grunt version to bump the version."
-        exit 666
+        set_error
       fi
     fi
   fi
@@ -130,31 +130,17 @@ after-deploy() {
 # UTILITY FUNCTIONS:
 ##
 
-# Prints a message about the section of the script.
-header() {
-  set +xv
-  echo
-  echo "** $@"
-  echo
-  set -xv
-}
-
 # Sets the exit level to error.
 set_error() {
   EXIT_VALUE=1
 }
 
 # Runs a command and sets an error if it fails.
-run_test() {
+run_command() {
+  set -xv
   if ! $@; then
     set_error
   fi
-}
-
-# Runs a command showing all the lines executed
-run_command() {
-  set -xv
-  $@
   set +xv
 }
 

--- a/scripts/travis-ci.sh
+++ b/scripts/travis-ci.sh
@@ -95,10 +95,8 @@ after-script() {
 # Clean up after the tests.
 #
 after-success() {
-  DISPLAY=:99.0 grunt prepare
-  cd $TRAVIS_BUILD_DIR/generated
-  npm install --production --ignore-scripts
-  grunt build
+  cd $TRAVIS_BUILD_DIR
+  DISPLAY=:99.0 grunt build
   cd $TRAVIS_BUILD_DIR
 }
 

--- a/src/modules/initialize/initialize.js
+++ b/src/modules/initialize/initialize.js
@@ -8,12 +8,14 @@ angular.module('kalabox.initialize', [])
     });
   })
   .controller('InitializeCtrl',
-  ['$scope', '$location', '_', 'VirtualBox', 'Boot2Docker',
-    function ($scope, $location, _, VirtualBox, Boot2Docker) {
+  ['$scope', '$location', '_', 'pconfig', 'VirtualBox', 'Boot2Docker',
+    function ($scope, $location, _, pconfig, VirtualBox, Boot2Docker) {
 
       var gui = require('nw.gui');
       var mb = new gui.Menu({type: 'menubar'});
-      mb.createMacBuiltin('Kalabox', {hideEdit: true, hideWindow: true});
+      if (pconfig.platform === 'darwin') {
+        mb.createMacBuiltin('Kalabox', {hideEdit: true, hideWindow: true});
+      }
       gui.Window.get().menu = mb;
 
       // Best practices is to manage our data in a scope object

--- a/src/modules/nodewrappers/nodewrappers.js
+++ b/src/modules/nodewrappers/nodewrappers.js
@@ -13,6 +13,9 @@ angular.module('kalabox.nodewrappers', [])
   .factory('os', [function() {
     return require('os');
   }])
+  .factory('pconfig', [function() {
+    return require('./lib/pconfig');
+  }])
   .factory('_', function() {
     return require('lodash');
   });

--- a/tasks/protractor-setup.js
+++ b/tasks/protractor-setup.js
@@ -28,11 +28,6 @@ module.exports = function(grunt) {
     var cdRemote = pconfig.chromedriverDownload;
     var cdLocal = path.resolve(dir, pconfig.chromedriverDownload.split('/').pop());
 
-    grunt.log.writeln(cdLocal);
-    done();
-    return;
-
-
     var download = function(url, dest, cb, cbdone) {
       var file = fs.createWriteStream(dest);
       http.get(url, function(response) {
@@ -48,10 +43,13 @@ module.exports = function(grunt) {
 
       if (pconfig.platform === 'linux') {
         var targz = require('tar.gz');
-        var compress = new targz().extract(cdLocal, dir, function(err){
+        var compress = new targz().extract(cdLocal, dir, function(err) {
           if(err)
             console.log(err);
 
+          var cdSrc = path.resolve(cdLocal.replace(/\.tar\.gz$/, ''), 'chromedriver');
+          fs.renameSync(cdSrc, cdFile); 
+          
           grunt.log.writeln('Protractor setup is complete.');
           grunt.log.writeln('To run tests, you may now run: grunt e2e');
           cbdone();

--- a/tasks/protractor-setup.js
+++ b/tasks/protractor-setup.js
@@ -28,6 +28,11 @@ module.exports = function(grunt) {
     var cdRemote = pconfig.chromedriverDownload;
     var cdLocal = path.resolve(dir, pconfig.chromedriverDownload.split('/').pop());
 
+    grunt.log.writeln(cdLocal);
+    done();
+    return;
+
+
     var download = function(url, dest, cb, cbdone) {
       var file = fs.createWriteStream(dest);
       http.get(url, function(response) {
@@ -41,22 +46,35 @@ module.exports = function(grunt) {
     var extractChromedriver = function(cbdone) {
       grunt.log.writeln('Extracting node-webkit chromedriver.');
 
-      fs.createReadStream(cdLocal)
-        .pipe(unzip.Parse())
-        .on('entry', function (entry) {
-          if (entry.path.indexOf('/chromedriver') >= 0) {
-            entry.pipe(fs.createWriteStream(cdFile));
-          } else {
-            entry.autodrain();
-          }
-        })
-        .on('finish', function() {
-          // *nix only?
-          fs.chmodSync(cdFile, 0755);
+      if (pconfig.platform === 'linux') {
+        var targz = require('tar.gz');
+        var compress = new targz().extract(cdLocal, dir, function(err){
+          if(err)
+            console.log(err);
+
           grunt.log.writeln('Protractor setup is complete.');
           grunt.log.writeln('To run tests, you may now run: grunt e2e');
           cbdone();
         });
+      }
+      else {
+        fs.createReadStream(cdLocal)
+          .pipe(unzip.Parse())
+          .on('entry', function (entry) {
+            if (entry.path.indexOf('/chromedriver') >= 0) {
+              entry.pipe(fs.createWriteStream(cdFile));
+            } else {
+              entry.autodrain();
+            }
+          })
+          .on('finish', function() {
+            // *nix only?
+            fs.chmodSync(cdFile, 0755);
+            grunt.log.writeln('Protractor setup is complete.');
+            grunt.log.writeln('To run tests, you may now run: grunt e2e');
+            cbdone();
+          });
+      }
     };
 
     if (!supportExists) {


### PR DESCRIPTION
I setup the project on ubuntu and killed some bugs.
- fixed osx-only call in initialize.js
- updated default grunt task to run the project (sorta unrelated)
- added decompression support for .tar.gz to the protractor setup task
- updated linux chromedriver download to the original .tar.gz 

With these changes, I can run the app and test with karma and protractor on ubuntu.
